### PR TITLE
chore(deps): update dependency typescript to v6

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,11 +3,19 @@ import { defineConfig } from "eslint/config";
 import obsidianmd from "eslint-plugin-obsidianmd";
 import globals from "globals";
 
+// Disable all obsidianmd rules for non-TS files.  Several rules in the
+// plugin's recommended config call getParserServices() but are applied
+// globally (no files filter), which crashes on package.json and other
+// non-TypeScript files that lack type information.
+const obsidianmdOff = Object.fromEntries(
+    Object.keys(obsidianmd.rules ?? {}).map((name) => [`obsidianmd/${name}`, "off"])
+);
+
 export default defineConfig([
-    ...obsidianmd.configs.recommended,
     {
-        ignores: ["main.js", "dist/**", "node_modules/**", "*.d.ts"],
+        ignores: ["main.js", "dist/**", "node_modules/**", "*.d.ts", "*.mjs"],
     },
+    ...obsidianmd.configs.recommended,
     {
         files: ["**/*.ts", "**/*.tsx"],
         languageOptions: {
@@ -25,6 +33,7 @@ export default defineConfig([
     {
         files: ["package.json"],
         rules: {
+            ...obsidianmdOff,
             "depend/ban-dependencies": "off",
         },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "obsidian": "latest",
                 "prettier": "^3.8.3",
                 "tslib": "2.8.1",
-                "typescript": "5.9.3"
+                "typescript": "6.0.3"
             }
         },
         "node_modules/@codemirror/state": {
@@ -6013,9 +6013,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "obsidian": "latest",
         "prettier": "^3.8.3",
         "tslib": "2.8.1",
-        "typescript": "5.9.3"
+        "typescript": "6.0.3"
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,json,css,scss,md}": [

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -94,8 +94,14 @@ export class ScrollEngine {
         pixelsPerFrame: number,
         totalFrames: number
     ): Promise<void> {
+        if (!this.activeElement) {
+            throw new Error("No active element");
+        }
+
+        const element = this.activeElement;
+
         return new Promise((resolve) => {
-            let currentPosition = this.activeElement.scrollTop;
+            let currentPosition = element.scrollTop;
             let framesProcessed = 0;
 
             const startTime = performance.now();
@@ -110,7 +116,7 @@ export class ScrollEngine {
             };
 
             const animate = () => {
-                const previousPosition = this.activeElement.scrollTop;
+                const previousPosition = element.scrollTop;
                 const nextPosition = currentPosition + pixelsPerFrame;
 
                 this.logger.debug(
@@ -121,7 +127,7 @@ export class ScrollEngine {
                 this.directScroll(currentPosition);
 
                 // check if we've reached a document limit
-                const actualPosition = this.activeElement.scrollTop;
+                const actualPosition = element.scrollTop;
                 if (actualPosition === previousPosition) {
                     finalize(`Scroll stopped @ ${actualPosition}`);
                     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,9 +53,9 @@ const config = new PluginConfig<StompPluginSettings>({
 });
 
 export default class StompPlugin extends Plugin {
-    settings: StompPluginSettings;
+    settings!: StompPluginSettings;
 
-    private controller: ScrollController;
+    private controller!: ScrollController;
 
     private logger: Logger = Logger.getLogger("main");
 
@@ -124,6 +124,6 @@ export default class StompPlugin extends Plugin {
 
     hasActiveView(): boolean {
         const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-        return activeView && activeView.currentMode instanceof MarkdownPreviewView;
+        return activeView !== null && activeView.currentMode instanceof MarkdownPreviewView;
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,18 @@
 {
     "compilerOptions": {
-        "baseUrl": ".",
         "inlineSourceMap": true,
         "inlineSources": true,
         "module": "ESNext",
         "target": "ES6",
         "allowJs": true,
         "noImplicitAny": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "importHelpers": true,
         "declaration": true,
         "outDir": "./dist",
+        "types": ["node"],
         "typeRoots": ["node_modules/@types"],
-        "lib": ["DOM", "ES6"]
+        "lib": ["DOM", "ES2017"]
     },
     "include": ["**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Upgrades TypeScript from 5.9.3 to 6.0.3 with all necessary compatibility fixes.

### Changes

- **tsconfig.json**: `moduleResolution` "node" → "bundler" (deprecated in TS6), removed unused `baseUrl`, added `"types": ["node"]` (TS6 no longer auto-includes @types/*), bumped `lib` to ES2017 for `Object.entries`
- **src/engine.ts**: Added null guard in `animatedScroll()` and captured `activeElement` in local var for stricter null checks
- **src/main.ts**: Definite assignment assertions for `settings`/`controller` (initialized in `onload`); explicit null check in `hasActiveView()`
- **eslint.config.mjs**: Updated for eslint-plugin-obsidianmd 0.2.4 — spread recommended config at top level, ignore .mjs build configs, disable type-checked obsidianmd rules for package.json (plugin bug: type-checked rules applied globally)

### Approach

Follows the same migration pattern as jheddings/obskit#175.

## Test plan

- [x] `npm run build` passes (tsc + esbuild)
- [x] `just preflight` passes (build + format + lint)
- [ ] Manual test in Obsidian vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)