### PR TITLE
chore: add git-cliff for structured release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v6.0.2
+              with:
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v6.4.0
@@ -30,11 +32,14 @@ jobs:
               id: version
               run: echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
+            - name: Generate release notes
+              run: npx git-cliff@latest --latest --strip header -o RELEASE_NOTES.md
+
             - name: Create release
               run: |
                   gh release create ${{ github.ref_name }} \
                     --title "obsidian-stomp-${{ github.ref_name }}" \
-                    --generate-notes --draft \
+                    --notes-file RELEASE_NOTES.md --draft \
                     ./main.js ./manifest.json ./styles.css
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.justfile
+++ b/.justfile
@@ -28,6 +28,10 @@ build: setup
 run: setup
 	npm run dev
 
+# preview release notes since the last tag (or for a given range)
+notes tag="--unreleased":
+	npx git-cliff@latest {{tag}}
+
 # verify no uncommitted changes to tracked files
 repo-guard:
 	test -z "$(git status --porcelain -uno)" || (echo "ERROR: working tree is dirty"; exit 1)

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,72 @@
+# git-cliff configuration
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = ""
+body = """
+{%- for group, commits in commits | group_by(attribute="group") %}
+{%- if group == "<!-- 4 -->Dependencies" %}
+## Dependencies
+{% for commit in commits | reverse | unique(attribute="scope") | sort(attribute="scope") -%}
+{%- set ver = commit.message | split(pat=" to ") | last -%}
+- {{ commit.scope }} → {{ ver }}
+{% endfor %}
+{%- else %}
+## {{ group | striptags | trim }}
+{% for commit in commits | filter(attribute="scope") | sort(attribute="scope") -%}
+- **({{ commit.scope }})** {{ commit.message | split(pat="\n") | first }}
+{% endfor -%}
+{% for commit in commits -%}
+{% if not commit.scope -%}
+- {{ commit.message | split(pat="\n") | first }}
+{% endif -%}
+{% endfor -%}
+{%- endif %}
+{%- endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "[0-9]+.[0-9]+.*"
+topo_order = false
+sort_commits = "oldest"
+
+commit_preprocessors = [
+  # strip PR/issue references for cleaner output
+  { pattern = ' ?\([#\d, ]+\)', replace = '' },
+]
+
+commit_parsers = [
+  # skip version bumps, lockfile maintenance, and merge commits
+  { message = "^obsidian-stomp-", skip = true },
+  { message = "^bump version", skip = true },
+  { message = "^chore\\(deps\\): lock file maintenance", skip = true },
+  { message = "^[Mm]erge", skip = true },
+
+  # skip docs (design specs, implementation plans)
+  { message = "^docs", skip = true },
+
+  # dependency updates — capture package name as scope
+  { message = "^fix\\(deps\\): update dependency (.+?) to", group = "<!-- 4 -->Dependencies", scope = "${1}" },
+  { message = "^chore\\(deps\\): update dependency (.+?) to", group = "<!-- 4 -->Dependencies", scope = "${1}" },
+  { message = "^fix\\(deps\\): update (.+?) monorepo to", group = "<!-- 4 -->Dependencies", scope = "${1}" },
+  { message = "^chore\\(deps\\): update (.+?) monorepo to", group = "<!-- 4 -->Dependencies", scope = "${1}" },
+
+  # standard type mapping
+  { message = "^feat", group = "<!-- 1 -->Features" },
+  { message = "^fix", group = "<!-- 2 -->Fixes" },
+  { message = "^chore", group = "<!-- 3 -->Maintenance" },
+  { message = "^refactor", group = "<!-- 3 -->Maintenance" },
+  { message = "^test", group = "<!-- 3 -->Maintenance" },
+  { message = "^style", group = "<!-- 3 -->Maintenance" },
+  { message = "^perf", group = "<!-- 3 -->Maintenance" },
+
+  # catch-all for unconventional commits
+  { message = ".*", skip = true },
+]


### PR DESCRIPTION
## Summary

- Add `cliff.toml` with conventional commit parsing, grouped output (Features, Fixes, Maintenance, Dependencies)
- Update release workflow to use `npx git-cliff --latest` instead of `--generate-notes`
- Add `just notes` recipe for local release notes preview

Closes #204

## Test plan

- [x] `just notes 0.7.0..0.7.1` produces grouped output locally
- [ ] Verify release workflow on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)